### PR TITLE
fix coordcompass.mixins.json error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.idea
+.gradle
+build

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,6 +10,6 @@ loader_version=0.17.2
 loom_version=1.11-SNAPSHOT
 
 # Mod Properties
-mod_version=2.1.9
+mod_version=2.1.10
 maven_group=com.damir00109
 archives_base_name=coordscompass

--- a/src/client/java/com/damir00109/mixin/MinecraftClientMixin.java
+++ b/src/client/java/com/damir00109/mixin/MinecraftClientMixin.java
@@ -1,0 +1,20 @@
+package com.damir00109.mixin;
+
+import com.damir00109.CompassRender;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.minecraft.client.MinecraftClient;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Environment(EnvType.CLIENT)
+@Mixin(MinecraftClient.class)
+public abstract class MinecraftClientMixin {
+
+    @Inject(method = "tick", at = @At("TAIL"))
+    private void coordscompass$onClientTick(CallbackInfo ci) {
+        CompassRender.onEndClientTick((MinecraftClient) (Object) this);
+    }
+}

--- a/src/client/resources/coordscompass.client.mixins.json
+++ b/src/client/resources/coordscompass.client.mixins.json
@@ -1,0 +1,12 @@
+{
+  "required": true,
+  "minVersion": "0.8",
+  "package": "com.damir00109.mixin",
+  "compatibilityLevel": "JAVA_21",
+  "client": [
+    "MinecraftClientMixin"
+  ],
+  "injectors": {
+    "defaultRequire": 1
+  }
+}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -14,7 +14,10 @@
 	"icon": "assets/coordscompass/icon.png",
 	"environment": "*",
 	"mixins": [
-		"coordscompass.mixins.json"
+		{
+			"config": "coordscompass.client.mixins.json",
+			"environment": "client"
+		}
 	],
 	"depends": {
 		"fabricloader": ">=0.17.2",


### PR DESCRIPTION
в модритче или плохой релиз, или я пиво

при скачивании последнего релиза (2.1.9) на версию 1.21.8 выдает ошибку:
`IllegalArgumentException: The specified resource 'coordscompass.mixins.json' was invalid or could not be read`
но в 2.1.9 попала версия sources.
скачал обычную версию [отсюда](https://github.com/Damir00109/CoordsCompass/releases/tag/v2.1.9%233), ошибка та же.
 
2.1.8 ворк

\+ связанно с [ишью](https://github.com/Damir00109/CoordsCompass/issues/1)

всем 🍻🍻🍻